### PR TITLE
v2.0.1 hotfix — Edge OAuth + single-source version + store badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # go-mapi
 
+[![Chrome Web Store](https://img.shields.io/chrome-web-store/v/ndhoimoncoekjmldllpbjdanamdhemcl?label=Chrome%20Web%20Store)](https://chromewebstore.google.com/detail/go-mapi/ndhoimoncoekjmldllpbjdanamdhemcl)
+[![Edge Add-ons](https://img.shields.io/badge/Edge%20Add--ons-go--mapi-blue)](https://microsoftedge.microsoft.com/addons/detail/gomapi/jfpjjkihpciojgaohonjooengomfbpom)
+[![GitHub Release](https://img.shields.io/github/v/release/marcfargas/go-mapi)](https://github.com/marcfargas/go-mapi/releases/latest)
+[![License: LGPL-3.0](https://img.shields.io/badge/License-LGPL--3.0-blue.svg)](LICENSE)
+
 **The MAPI-to-Gmail bridge you always wanted.**
 
 ## Overview

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-mapi",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "MAPI to Gmail bridge for Windows - send emails via Gmail from any Windows application",
   "private": true,
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-mapi",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "MAPI to Gmail bridge for Windows - send emails via Gmail from any Windows application",
   "private": true,
   "workspaces": [

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-mapi-extension",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "go-mapi Browser Extension - Send emails via Gmail from Windows MAPI applications",
   "type": "module",
   "scripts": {

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-mapi-extension",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "go-mapi Browser Extension - Send emails via Gmail from Windows MAPI applications",
   "type": "module",
   "scripts": {

--- a/src/extension/public/manifest.json
+++ b/src/extension/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "go-mapi",
-  "version": "1.0.0",
+  "version": "0.0.0-dev",
   "description": "Send emails via Gmail from Windows MAPI applications (right-click → Send to → Mail recipient)",
   "permissions": [
     "nativeMessaging",
@@ -20,6 +20,7 @@
       "https://www.googleapis.com/auth/gmail.send"
     ]
   },
+  "oauth2_web_client_id": "757265040228-rlau98id208j1rg4pvrfl844hhsietgf.apps.googleusercontent.com",
   "background": {
     "service_worker": "service-worker.js",
     "type": "module"

--- a/src/extension/src/background/service-worker.ts
+++ b/src/extension/src/background/service-worker.ts
@@ -262,22 +262,59 @@ function handleNativeMessage(message: NativeIncomingMessage) {
   }
 }
 
+// --- OAuth helper: Chrome getAuthToken with launchWebAuthFlow fallback ---
+// getAuthToken is Chrome-only; Edge throws "This API is not supported on
+// Microsoft Edge". launchWebAuthFlow works on all Chromium browsers.
+
+async function getOAuthToken(interactive = true): Promise<string> {
+  try {
+    return await new Promise<string>((resolve, reject) => {
+      chrome.identity.getAuthToken({ interactive }, (t) => {
+        if (chrome.runtime.lastError || !t) {
+          reject(new Error(chrome.runtime.lastError?.message || 'Auth failed'));
+        } else {
+          resolve(t);
+        }
+      });
+    });
+  } catch (err) {
+    if (!interactive) throw err;
+
+    // manifest oauth2.client_id is "Chrome extension" type — Chrome-only.
+    // oauth2_web_client_id is "Web application" type — works everywhere.
+    const manifest = chrome.runtime.getManifest() as Record<string, unknown>;
+    const webClientId = manifest.oauth2_web_client_id as string | undefined;
+    if (!webClientId) throw new Error('No oauth2_web_client_id in manifest');
+    const scopes = ((manifest.oauth2 as Record<string, unknown>)?.scopes as string[] | undefined)?.join(' ') ?? '';
+
+    const redirectUrl = chrome.identity.getRedirectURL();
+    const authUrl =
+      `https://accounts.google.com/o/oauth2/v2/auth?` +
+      `client_id=${encodeURIComponent(webClientId)}&` +
+      `redirect_uri=${encodeURIComponent(redirectUrl)}&` +
+      `response_type=token&` +
+      `scope=${encodeURIComponent(scopes)}`;
+
+    const responseUrl = await chrome.identity.launchWebAuthFlow({
+      url: authUrl,
+      interactive: true,
+    });
+    if (!responseUrl) throw new Error('OAuth flow cancelled or returned no URL');
+
+    const hash = new URL(responseUrl).hash.substring(1);
+    const token = new URLSearchParams(hash).get('access_token');
+    if (!token) throw new Error('No access_token in OAuth response');
+    return token;
+  }
+}
+
 // --- Auto-draft: get token, send email to Go host ---
 
 async function autoCreateDraft(email: EmailWithId) {
   try {
-    // Try non-interactive auth first
     let token: string;
     try {
-      token = await new Promise<string>((resolve, reject) => {
-        chrome.identity.getAuthToken({ interactive: false }, (t) => {
-          if (chrome.runtime.lastError || !t) {
-            reject(new Error(chrome.runtime.lastError?.message || 'Not signed in'));
-          } else {
-            resolve(t);
-          }
-        });
-      });
+      token = await getOAuthToken(false);
     } catch {
       // Not signed in — show notification
       chrome.notifications.create(`auth:${email.id}`, {
@@ -319,13 +356,13 @@ chrome.notifications.onClicked.addListener((notificationId) => {
     });
     chrome.notifications.clear(notificationId);
   } else if (notificationId.startsWith('auth:')) {
-    chrome.identity.getAuthToken({ interactive: true }, (token) => {
+    getOAuthToken(true).then((token) => {
       if (token) {
         for (const email of emails.values()) {
           autoCreateDraft(email);
         }
       }
-    });
+    }).catch(() => { /* user cancelled or auth failed */ });
     chrome.notifications.clear(notificationId);
   }
 });
@@ -360,13 +397,7 @@ chrome.runtime.onMessage.addListener((request, _sender, sendResponse) => {
             sendResponse({ success: false, error: 'Email not found' });
             return;
           }
-          // Get token and delegate to Go
-          const token = await new Promise<string>((resolve, reject) => {
-            chrome.identity.getAuthToken({ interactive: true }, (t) => {
-              if (chrome.runtime.lastError || !t) reject(new Error(chrome.runtime.lastError?.message || 'Auth failed'));
-              else resolve(t);
-            });
-          });
+          const token = await getOAuthToken();
           sendToNativeHost({ type: MSG_TYPE.CREATE_DRAFT, id: request.id, token, email });
           sendResponse({ success: true });
           break;

--- a/src/extension/vite.config.ts
+++ b/src/extension/vite.config.ts
@@ -1,9 +1,23 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
+import { readFileSync, writeFileSync } from 'fs';
+
+function stampManifestVersion(): Plugin {
+  return {
+    name: 'stamp-manifest-version',
+    writeBundle({ dir }) {
+      const rootPkg = JSON.parse(readFileSync(resolve(__dirname, '../../package.json'), 'utf-8'));
+      const manifestPath = resolve(dir!, 'manifest.json');
+      const manifest = JSON.parse(readFileSync(manifestPath, 'utf-8'));
+      manifest.version = rootPkg.version;
+      writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), stampManifestVersion()],
   build: {
     outDir: 'dist',
     emptyOutDir: true,


### PR DESCRIPTION
## Summary

- **Edge OAuth**: `chrome.identity.getAuthToken` is Chrome-only. Added `launchWebAuthFlow` fallback so Edge/Brave/Vivaldi users get a Google sign-in popup. `oauth2_web_client_id` in manifest.json (Web Application type client).
- **Single-source version**: root `package.json` is the single source of truth. Vite `stampManifestVersion` plugin stamps it into `dist/manifest.json` at build time. No more manual version sync across 3 files.
- **Store badges**: Chrome Web Store + Edge Add-ons + GitHub Release + License badges in README.

## Test plan

- [x] Edge smoke test: launchWebAuthFlow popup appears and completes draft creation
- [ ] CI: build + installer-smoke + e2e (running on PR)
- [ ] After merge: tag v2.0.1, `releases/latest` URL auto-flips

🤖 Generated with [Claude Code](https://claude.com/claude-code)